### PR TITLE
Downgrade capacitor version and rename package

### DIFF
--- a/AppboxoCapacitorBoxoSdk.podspec
+++ b/AppboxoCapacitorBoxoSdk.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'CapacitorBoxoSdk'
+  s.name = 'AppboxoCapacitorBoxoSdk'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']

--- a/Package.swift
+++ b/Package.swift
@@ -2,11 +2,11 @@
 import PackageDescription
 
 let package = Package(
-    name: "CapacitorBoxoSdk",
+    name: "AppboxoCapacitorBoxoSdk",
     platforms: [.iOS(.v13)],
     products: [
         .library(
-            name: "CapacitorBoxoSdk",
+            name: "AppboxoCapacitorBoxoSdk",
             targets: ["AppboxoPlugin"])
     ],
     dependencies: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
-  "name": "capacitor-boxo-sdk",
-  "version": "0.0.1",
+  "name": "@appboxo/capacitor-boxo-sdk",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "capacitor-boxo-sdk",
-      "version": "0.0.1",
+      "name": "@appboxo/capacitor-boxo-sdk",
+      "version": "0.0.3",
       "license": "MIT",
       "devDependencies": {
-        "@capacitor/android": "^5.7.7",
-        "@capacitor/core": "^5.7.7",
+        "@capacitor/android": "^5.2.2",
+        "@capacitor/core": "^5.2.2",
         "@capacitor/docgen": "^0.2.2",
-        "@capacitor/ios": "^5.7.7",
+        "@capacitor/ios": "^5.2.2",
         "@ionic/eslint-config": "^0.4.0",
         "@ionic/prettier-config": "^1.0.1",
         "@ionic/swiftlint-config": "^1.1.2",
@@ -25,7 +25,7 @@
         "typescript": "~4.1.5"
       },
       "peerDependencies": {
-        "@capacitor/core": "^5.7.7"
+        "@capacitor/core": "^5.2.2"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ios/Sources",
     "ios/Tests",
     "Package.swift",
-    "CapacitorBoxoSdk.podspec"
+    "AppboxoCapacitorBoxoSdk.podspec"
   ],
   "author": "Appboxo pte. ltd",
   "license": "MIT",
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "verify": "npm run verify:ios && npm run verify:android && npm run verify:web",
-    "verify:ios": "xcodebuild -scheme CapacitorBoxoSdk -destination generic/platform=iOS",
+    "verify:ios": "xcodebuild -scheme AppboxoCapacitorBoxoSdk -destination generic/platform=iOS",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",

--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
     "prepublishOnly": "npm run build"
   },
   "devDependencies": {
-    "@capacitor/android": "^5.7.7",
-    "@capacitor/core": "^5.7.7",
+    "@capacitor/android": "^5.2.2",
+    "@capacitor/core": "^5.2.2",
     "@capacitor/docgen": "^0.2.2",
-    "@capacitor/ios": "^5.7.7",
+    "@capacitor/ios": "^5.2.2",
     "@ionic/eslint-config": "^0.4.0",
     "@ionic/prettier-config": "^1.0.1",
     "@ionic/swiftlint-config": "^1.1.2",
@@ -62,7 +62,7 @@
     "typescript": "~4.1.5"
   },
   "peerDependencies": {
-    "@capacitor/core": "^5.7.7"
+    "@capacitor/core": "^5.2.2"
   },
   "prettier": "@ionic/prettier-config",
   "swiftlint": "@ionic/swiftlint-config",


### PR DESCRIPTION
### 01 - Downgrading capacitor core:
We are currently on capacitor `5.2.2` so I'm updating the plugins dependencies to match our versions

![image](https://github.com/user-attachments/assets/7128be61-0c83-4d8c-8513-ae9591e33db1)


### 02 - Renaming package:
While running `npx cap sync`, Ionic tried to automatically find a package named `AppboxoCapacitorBoxoSdk` instead of the current `CapacitorBoxoSdk`.

<img width="805" alt="Screenshot 2024-07-29 at 4 13 30 PM" src="https://github.com/user-attachments/assets/ff9a2d9a-8bf3-473e-ab77-b7a882beaf98">
