### PR TITLE
Add orderPaymentId field to Payment. v0.14.0

### DIFF
--- a/AppboxoCapacitorBoxoSdk.podspec
+++ b/AppboxoCapacitorBoxoSdk.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/Sources/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target = '14.0'
   s.dependency 'Capacitor'
-  s.dependency 'BoxoSDK', '1.27.6'
+  s.dependency 'BoxoSDK', '1.28.0'
   s.swift_version = '5.1'
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.14.0]
+- add orderPaymentId field to Payment
+
 ## [0.13.1]
 - add Lottie animation as a miniapp loader
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation project(':capacitor-android')
-    implementation('io.boxo.sdk:boxo-android:1.41.1')
+    implementation('io.boxo.sdk:boxo-android:1.42.0')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"

--- a/android/src/main/java/io/boxo/sdk/capacitor/AppboxoPlugin.kt
+++ b/android/src/main/java/io/boxo/sdk/capacitor/AppboxoPlugin.kt
@@ -252,6 +252,7 @@ class AppboxoPlugin : Plugin(), Miniapp.LifecycleListener,
             val appId: String = call.getString("appId")!!
             val data = PaymentData(
                 call.getString("transactionToken") ?: "",
+                call.getString("orderPaymentId") ?: "",
                 call.getString("miniappOrderId") ?: "",
                 call.getDouble("amount") ?: 0.0,
                 call.getString("currency") ?: "",
@@ -320,6 +321,7 @@ class AppboxoPlugin : Plugin(), Miniapp.LifecycleListener,
         params.put("appId", miniapp.appId)
         try {
             params.put("transactionToken", paymentData.transactionToken)
+            params.put("orderPaymentId", paymentData.orderPaymentId)
             params.put("miniappOrderId", paymentData.miniappOrderId)
             params.put("amount", paymentData.amount)
             params.put("currency", paymentData.currency)

--- a/ios/Sources/AppboxoPlugin/AppboxoPlugin.swift
+++ b/ios/Sources/AppboxoPlugin/AppboxoPlugin.swift
@@ -199,6 +199,7 @@ public class AppboxoPlugin: CAPPlugin, CAPBridgedPlugin {
 
         let paymentData = PaymentData()
         paymentData.transactionToken = call.getString("transactionToken") ?? ""
+        paymentData.orderPaymentId = call.getString("orderPaymentId") ?? ""
         paymentData.miniappOrderId = call.getString("miniappOrderId") ?? ""
         paymentData.amount = call.getDouble("amount", 0.0)
         paymentData.currency = call.getString("currency") ?? ""
@@ -250,6 +251,7 @@ extension AppboxoPlugin : MiniappDelegate {
         let dict = [
             "appId" : miniapp.appId,
             "transactionToken" : paymentData.transactionToken,
+            "orderPaymentId" : paymentData.orderPaymentId,
             "miniappOrderId" : paymentData.miniappOrderId,
             "amount" : paymentData.amount,
             "currency" : paymentData.currency,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appboxo/capacitor-boxo-sdk",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "description": "A capacitor wrapper over Appboxo SDK for IOS and Android.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -169,6 +169,7 @@ export interface CustomEvent {
 export interface PaymentEvent {
   appId: string;
   transactionToken?: string;
+  orderPaymentId?: string;
   miniappOrderId?: string;
   amount: number;
   currency?: string;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds orderPaymentId to payment events across JS, Android, and iOS so clients can link payments to orders. Also releases `@appboxo/capacitor-boxo-sdk` v0.14.0 with updated native SDKs.

- **New Features**
  - `PaymentEvent` now includes optional `orderPaymentId`.
  - Android and iOS read and emit `orderPaymentId` in `PaymentData` and event payloads.

- **Dependencies**
  - Bump `io.boxo.sdk:boxo-android` to 1.42.0.
  - Bump `BoxoSDK` (iOS) to 1.28.0.

<sup>Written for commit 03b3e6e7482ee5a6cedd8228bfe960053cd31633. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Appboxo/capacitor-appboxo-sdk/pull/9?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `orderPaymentId` field to payment events for enhanced order tracking and identification.

* **Chores**
  * Updated SDK dependencies to latest compatible versions across iOS and Android platforms.
  * Version bumped to 0.14.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->